### PR TITLE
Fix wrong execution date in SLA alerts

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -472,17 +472,18 @@ class DagFileProcessor(LoggingMixin):
             sla_misses = []
             next_info = dag.next_dagrun_info(dag.get_run_data_interval(ti.dag_run), restricted=False)
             while next_info and next_info.logical_date < ts:
+                ti_logical_date = next_info.logical_date
                 next_info = dag.next_dagrun_info(next_info.data_interval, restricted=False)
 
                 if next_info is None:
                     break
-                if (ti.dag_id, ti.task_id, next_info.logical_date) in recorded_slas_query:
+                if (ti.dag_id, ti.task_id, ti_logical_date) in recorded_slas_query:
                     continue
                 if next_info.logical_date + task.sla < ts:
                     sla_miss = SlaMiss(
                         task_id=ti.task_id,
                         dag_id=ti.dag_id,
-                        execution_date=next_info.logical_date,
+                        execution_date=ti_logical_date,
                         timestamp=ts,
                     )
                     sla_misses.append(sla_miss)


### PR DESCRIPTION
### Intent
This PR is trying to fix the incorrect execution date shown in SLA alerts.


### Context

- The execution date in a triggered SLA alert is one schedule interval ahead of the expected one. 

- In other words, the execution date of the SLA record inserted into the `SlaMiss` table is incorrect.

- For example, if a daily task with an execution date `2023-10-23 21:00:00` triggers an SLA alert, the execution date in that alert will be `2023-10-24 21:00:00` rather than `2023-10-23 21:00:00`.


### How to reproduce

1. Create a simple DAG scheduled every 5 minutes

```
import datetime
from airflow.models import DAG
from airflow.operators.bash import BashOperator

DEFAULT_ARGS = {
    "owner": "test",
    "email": ["test@email.com"]
}

dag = DAG(
    dag_id="test_dag",
    schedule_interval="*/5 * * * *",
    start_date=datetime.datetime(2023, 10, 20),
    catchup=False
)

with dag:
  task = BashOperator(
      task_id="task",
      bash_command="sleep 120; dummy command",
      sla=datetime.timedelta(minutes=1))
```

2. Enable the DAG and mark its first dagrun with execution date T as success.
3. Its second dagrun with execution date T+5 should fail and trigger an SLA alert at T + 11 (T + 5 + 5 + 1).
     However, the execution date of the task in this alert will be T + 10 instead of T + 5, which is not correct.
4. Also, the SLA record in the `SlaMiss` table has a wrong execution date as well.


### Validation
- The above DAG is able to trigger SLA alerts with correct execution dates.
- Add one additional test case to cover this logic.